### PR TITLE
Bump enonic libs for XP 8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 lib-thymeleaf = "3.0.0-SNAPSHOT"
 lib-http-client = "3.2.2"
-lib-util = "3.1.1"
+lib-util = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "lib-thymeleaf" }


### PR DESCRIPTION
## Summary

Pin `com.enonic.lib:lib-util` to the next-major SNAPSHOT published from master after the XP 8 upgrade. We are not releasing yet — consumers point directly at the SNAPSHOT.

| Lib | Before | After |
|---|---|---|
| `com.enonic.lib:lib-util` | `3.1.1` | `4.0.0-SNAPSHOT` |

`lib-menu` and `lib-explorer` are not consumed by this app, so no other bumps were needed.

The new pin is a SNAPSHOT and resolves from the Enonic dev/snapshot Maven repo. That repo is already declared via `xp.enonicRepo("dev")` in `build.gradle`, so no `repositories {}` change was needed.

## Excludes audited

- **Excludes removed:** none — the only `lib-util` reference (in `gradle/libs.versions.toml`) had no `exclude` clauses to begin with. `./gradlew dependencies --configuration include` confirms `lib-util:4.0.0-SNAPSHOT` resolves as a leaf with no transitive deps that would need filtering.
- **Excludes kept:** none.

## Verification

- `./gradlew clean build` — green.
- `./gradlew dependencies --configuration include` confirms `com.enonic.lib:lib-util:4.0.0-SNAPSHOT` resolves.
- Runtime verification (loading the app into a running XP 8 instance) was **not** performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)