### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # Project settings
 #
 group = com.enonic.app
-version = 2.2.0-SNAPSHOT
+version = 3.0.0-SNAPSHOT
 projectName = formbuilder
 appName = com.enonic.app.formbuilder
 xpVersion = 8.0.0-B4


### PR DESCRIPTION
## Summary
- Bump master `version` from `2.2.0-SNAPSHOT` to `3.0.0-SNAPSHOT`. Master targets XP 8 going forward (`xpVersion = 8.0.0-B4` is already set).
- Add a `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `2.x`, so the release tooling treats each as a release branch.
- The XP 7 maintenance line continues on the new `2.x` branch (created at `aaf66d3` — the post-`v2.1.0` SNAPSHOT commit, where `version=2.2.0-SNAPSHOT`).

## Test plan
- [ ] Workflow run on this PR succeeds.
- [ ] After merge, master CI run is green and `./gradlew clean build` is green locally.