### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -1,26 +1,29 @@
 name: Gradle Build
 
-on: [push]
+on: [ push ]
 
 jobs:
   build:
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.build-and-publish.outputs.release }}
+    steps:
+      - id: build-and-publish
+        uses: enonic/release-tools/build-and-publish@master
+        with:
+          repoUser: ci
+          repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
+  release:
     runs-on: ubuntu-latest
 
+    needs: build
+    if: needs.build.outputs.release == 'true'
+
     steps:
-      - uses: actions/checkout@v2.3.4
-
-      - uses: actions/setup-java@v1
+      - uses: enonic/release-tools/release@master
         with:
-          java-version: 11
-
-      - uses: actions/cache@v2.1.4
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - run: ./gradlew build
-
-      - uses: codecov/codecov-action@v1.3.1
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Update `.github/workflows/enonic-gradle.yml` on the new `2.x` maintenance branch to invoke `enonic/release-tools/build-and-publish@master` and declare a `releaseBranch:` block listing both `master` and `2.x`. This is required so pushes to `2.x` are recognized as release-branch builds — the action reads `releaseBranch:` from the branch's own workflow file.
- This branch was created off `aaf66d3` (post-`v2.1.0` SNAPSHOT bump). `gradle.properties` stays at `version = 2.2.0-SNAPSHOT` and `xpVersion = 7.1.0`. No version, docgen, or `versions.json` changes — those belong on master only.
- Companion to enonic/app-formbuilder#68 (master bump to 3.0.0-SNAPSHOT).

## Test plan
- [ ] Workflow run on this PR succeeds.
- [ ] After merge, a CI run on `2.x` classifies it as a release branch.