### PR TITLE
Bump lib-http-client to XP8 SNAPSHOT

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 lib-thymeleaf = "3.0.0-SNAPSHOT"
-lib-http-client = "3.2.2"
+lib-http-client = "4.0.0-SNAPSHOT"
 lib-util = "4.0.0-SNAPSHOT"
 
 [libraries]


### PR DESCRIPTION
## Summary

`lib-http-client 3.2.2` is the last enonic-lib dep still on a pre-XP8 release. Bump to the XP8 SNAPSHOT.

- `lib-http-client` 3.2.2 → 4.0.0-SNAPSHOT

Repo already uses `xp.enonicRepo("dev")`, so no repo change needed.

## Test plan

- [ ] `./gradlew build --refresh-dependencies` resolves the SNAPSHOT and tests pass
- [ ] E2E smoke against XP 8