### PR TITLE
Drop lib-util

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ dependencies {
     include xplibs.cluster
     include libs.lib.thymeleaf
     include libs.lib.http.client
-    include libs.lib.util
     //include "com.enonic.lib:recaptcha:1.1.1"
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,7 @@
 [versions]
 lib-thymeleaf = "3.0.0-SNAPSHOT"
 lib-http-client = "3.2.2"
-lib-util = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "lib-thymeleaf" }
 lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "lib-http-client" }
-lib-util = { module = "com.enonic.lib:lib-util", version.ref = "lib-util" }

--- a/src/main/resources/admin/extensions/formreport/formreport.js
+++ b/src/main/resources/admin/extensions/formreport/formreport.js
@@ -4,7 +4,6 @@ var thymeleaf = require('/lib/thymeleaf');
 var ioLib = require('/lib/xp/io');
 var nodeLib = require('/lib/xp/node');
 var authLib = require('/lib/xp/auth');
-var util = require('/lib/util/data');
 var moment = require('/lib/moment.min.js');
 
 var view = resolve('formreport.html');
@@ -36,7 +35,7 @@ function handleGet(req) {
     var contentPermissions = contentLib.getPermissions({
         key: contentId
     });
-    var principalsWhoMayWrite = util.forceArray(contentPermissions.permissions).map(function (permission) {
+    var principalsWhoMayWrite = (Array.isArray(contentPermissions.permissions) ? contentPermissions.permissions : [contentPermissions.permissions]).map(function (permission) {
         if (permission.allow.indexOf('WRITE_PERMISSIONS') >= 0 || permission.deny.indexOf('WRITE_PERMISSIONS') < 0) {
             return permission.principal;
         }
@@ -78,7 +77,7 @@ function handleGet(req) {
         if (site && site.data && site.data.siteConfig) {
             // Traverse siteConfigs for one or all apps of a site, returning the config for the last match of this app (should only be one match anyway)
             // This is basically just the same as portalLib.getSiteConfig() if the current site was already in the context
-            util.forceArray(site.data.siteConfig).forEach(function (sc, index) {
+            (Array.isArray(site.data.siteConfig) ? site.data.siteConfig : [site.data.siteConfig]).forEach(function (sc, index) {
                 if (sc.applicationKey === app.name) {
                     siteConfig = sc.config;
                 }

--- a/src/main/resources/lib/form-builder/form-response.js
+++ b/src/main/resources/lib/form-builder/form-response.js
@@ -4,7 +4,6 @@ var mail = require('/lib/xp/mail'); // Import the mail functions
 var nodeLib = require('/lib/xp/node'); // Import the node functions
 var portal = require('/lib/xp/portal'); // Import the portal functions
 var repo = require('/lib/xp/repo'); // Import the repo functions
-var util = require('/lib/util/data'); // Import the enonic util functions
 
 var CheckboxInputMapper = require('/lib/form-builder/mapper/checkbox-input-mapper');
 
@@ -274,7 +273,7 @@ var sendEmailToRecipients = function(formData, siteConfig, formConfig, request, 
 
   // Populate arrays with input display names and values, in the same order as in the formConfig
   // irrelevant inputs such as headings are still included, in order to enforce a strict index correspondence between inputDisplayNames[] and inputValues[]
-  util.forceArray(formConfig.inputs).forEach(function(inputConfig) {
+  (Array.isArray(formConfig.inputs) ? formConfig.inputs : [formConfig.inputs]).forEach(function(inputConfig) {
     // Empty strings by default, since all this will be concatenated into a single string in the end
     var label = inputConfig.label || '';
     var name = encodeURIComponent(inputConfig.name || inputConfig.label).replace(/\./g, '_');
@@ -351,7 +350,7 @@ var sendEmailToRecipients = function(formData, siteConfig, formConfig, request, 
   if (formConfig.emailSubscribers) {
     var mailParams = {
       from: systemEmailAddr || 'noreply@example.com',
-      to: util.forceArray(formConfig.emailSubscribers),
+      to: (Array.isArray(formConfig.emailSubscribers) ? formConfig.emailSubscribers : [formConfig.emailSubscribers]),
       subject: subject,
       body: '<code>' + formDataBeautified + '</code>',
       attachments: emailAttachments,

--- a/src/main/resources/services/formreport-singleresponse/formreport-singleresponse.js
+++ b/src/main/resources/services/formreport-singleresponse/formreport-singleresponse.js
@@ -3,7 +3,6 @@ var contentLib = require('/lib/xp/content');
 var nodeLib = require('/lib/xp/node');
 var authLib = require('/lib/xp/auth');
 var thymeleaf = require('/lib/thymeleaf');
-var util = require('/lib/util/data');
 
 var formbuilderRepo = nodeLib.connect({
     repoId: 'com.enonic.formbuilder',
@@ -25,7 +24,7 @@ function handleGet(req) {
         var contentPermissions = contentLib.getPermissions({
             key: formId
         });
-        var principalsWhoMayWrite = util.forceArray(contentPermissions.permissions).map(function (permission) {
+        var principalsWhoMayWrite = (Array.isArray(contentPermissions.permissions) ? contentPermissions.permissions : [contentPermissions.permissions]).map(function (permission) {
             if (permission.allow.indexOf('WRITE_PERMISSIONS') >= 0 || permission.deny.indexOf('WRITE_PERMISSIONS') < 0) {
                 return permission.principal;
             }
@@ -55,7 +54,7 @@ function handleGet(req) {
                 // Replace attachment metadata with downloadable links to the same attachments
                 Object.keys(formResponse.data).forEach(function (key) {
                     if (formResponse.data[key] && typeof formResponse.data[key] == 'object' && formResponse.data[key].attachments) {
-                        util.forceArray(formResponse.data[key].attachments).forEach(function (attachment) {
+                        (Array.isArray(formResponse.data[key].attachments) ? formResponse.data[key].attachments : [formResponse.data[key].attachments]).forEach(function (attachment) {
                             if (attachment.id && attachment.name) {
                                 files.push({
                                     url: portalLib.serviceUrl({

--- a/src/main/resources/services/formreport/formreport.js
+++ b/src/main/resources/services/formreport/formreport.js
@@ -2,15 +2,14 @@ var contentLib = require('/lib/xp/content');
 var portalLib = require('/lib/xp/portal');
 var nodeLib = require('/lib/xp/node');
 var thymeleafLib = require('/lib/thymeleaf');
-var util = require('/lib/util/data');
 var moment = require('/lib/moment.min.js');
 
 function createCSV(responses, formContent, format) {
     var separator = (format === 'csv-sc' || format === 'csv-no') ? ';' : ',';
-    var fieldReferences = util.forceArray(formContent.data.inputs).map(function (inputConfig) {
+    var fieldReferences = (Array.isArray(formContent.data.inputs) ? formContent.data.inputs : [formContent.data.inputs]).map(function (inputConfig) {
         return encodeURIComponent(inputConfig.name || inputConfig.label).replace(/\./g, '_');
     });
-    var fieldNames = util.forceArray(formContent.data.inputs).map(function (inputConfig) {
+    var fieldNames = (Array.isArray(formContent.data.inputs) ? formContent.data.inputs : [formContent.data.inputs]).map(function (inputConfig) {
         return inputConfig.label;
     });
     // Add extra column for the response timestamps
@@ -27,7 +26,7 @@ function createCSV(responses, formContent, format) {
             Object.keys(response.data).forEach(function (key) {
                 if (response.data[key] && typeof response.data[key] == 'object' && response.data[key].attachments) {
                     var inputAttachmentNames = [];
-                    util.forceArray(response.data[key].attachments).forEach(function (attachment) {
+                    (Array.isArray(response.data[key].attachments) ? response.data[key].attachments : [response.data[key].attachments]).forEach(function (attachment) {
                         if (attachment.id && attachment.name) {
                             inputAttachmentNames.push(attachment.name);
                         }
@@ -78,10 +77,10 @@ function createCSV(responses, formContent, format) {
 }
 
 function createModelForHTML(responses, formContent) {
-    var fieldReferences = util.forceArray(formContent.data.inputs).map(function (inputConfig) {
+    var fieldReferences = (Array.isArray(formContent.data.inputs) ? formContent.data.inputs : [formContent.data.inputs]).map(function (inputConfig) {
         return encodeURIComponent(inputConfig.name || inputConfig.label).replace(/\./g, '_');
     });
-    var fieldNames = util.forceArray(formContent.data.inputs).map(function (inputConfig) {
+    var fieldNames = (Array.isArray(formContent.data.inputs) ? formContent.data.inputs : [formContent.data.inputs]).map(function (inputConfig) {
         return inputConfig.label;
     });
 
@@ -114,7 +113,7 @@ function createModelForHTML(responses, formContent) {
                 // Replace attachment metadata with downloadable links to the same attachments
                 if (response.data[key] && typeof response.data[key] == 'object' && response.data[key].attachments) {
                     cell.attachments = [];
-                    util.forceArray(response.data[key].attachments).forEach(function (attachment) {
+                    (Array.isArray(response.data[key].attachments) ? response.data[key].attachments : [response.data[key].attachments]).forEach(function (attachment) {
                         if (attachment.id && attachment.name) {
                             cell.attachments.push({
                                 text: attachment.name,
@@ -152,7 +151,7 @@ function createModelForHTML(responses, formContent) {
                 // Replace attachment metadata with downloadable links to the same attachments
                 if (field && typeof field == 'object' && field.attachments) {
                     cell.attachments = [];
-                    util.forceArray(field.attachments).forEach(function (attachment) {
+                    (Array.isArray(field.attachments) ? field.attachments : [field.attachments]).forEach(function (attachment) {
                         if (attachment.id && attachment.name) {
                             cell.attachments.push({
                                 text: attachment.name,
@@ -273,7 +272,7 @@ function handleGet(req) {
                 var relatedAttachmentIds = [];
                 Object.keys(response.data).forEach(function (key) {
                     if (response.data[key] && typeof response.data[key] == 'object' && response.data[key].attachments) {
-                        util.forceArray(response.data[key].attachments).forEach(function (attachment) {
+                        (Array.isArray(response.data[key].attachments) ? response.data[key].attachments : [response.data[key].attachments]).forEach(function (attachment) {
                             if (attachment.id) {
                                 relatedAttachmentIds.push(attachment.id);
                             }


### PR DESCRIPTION
## Summary

This app's only use of `lib-util` was `util.forceArray(...)` (9 call sites across 4 files). Inline each as `(Array.isArray(x) ? x : [x])` — Nashorn-safe, matches lib-util's semantics including the `forceArray(null) === [null]` edge case — and drop the dependency.

## Files touched

- `src/main/resources/lib/form-builder/form-response.js` (2 call sites)
- `src/main/resources/admin/extensions/formreport/formreport.js` (2 call sites)
- `src/main/resources/services/formreport-singleresponse/formreport-singleresponse.js` (2 call sites)
- `src/main/resources/services/formreport/formreport.js` (7 call sites incl. one inside a commented-out block — kept consistent so the comment doesn't reference an undefined `util` binding)
- `build.gradle` — drop `include libs.lib.util`
- `gradle/libs.versions.toml` — drop the version + library entries

## Test plan

- [x] `./gradlew build` passes (locally — `BUILD SUCCESSFUL`)
- [x] `grep -r "/lib/util" src/` returns no matches
- [x] Built jar no longer contains any `com/enonic/lib/util/*` resources