### PR TITLE
Migrate to lib-asset #73

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     include xplibs.cluster
     include libs.lib.thymeleaf
     include libs.lib.http.client
+    include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"
     //include "com.enonic.lib:recaptcha:1.1.1"
 }
 

--- a/src/main/resources/cms/parts/form-part/form-part.js
+++ b/src/main/resources/cms/parts/form-part/form-part.js
@@ -1,4 +1,5 @@
 var portal = require('/lib/xp/portal');
+var assetLib = require('/lib/enonic/asset');
 var thymeleaf = require('/lib/thymeleaf');
 var contentLib = require('/lib/xp/content');
 var recaptcha = require('/lib/recaptcha');
@@ -30,7 +31,7 @@ var createCssUrl = function(style) {
     } else if (pathOrUrl.contains("://")) {
         return pathOrUrl; // Absolute URL. Doesn't need handling.
     } else {
-        return portal.assetUrl({path: styleConfig[style].css});
+        return assetLib.assetUrl({path: styleConfig[style].css});
     }
 };
 
@@ -108,7 +109,7 @@ exports.get = function(request) {
     var view = resolve(styleConfig[style].view);
 
     // Get client-side JavaScript for the formbuilder
-    var formScript = portal.assetUrl({
+    var formScript = assetLib.assetUrl({
         path: 'js/formbuilder.js'
     });
 

--- a/src/main/resources/cms/site.yaml
+++ b/src/main/resources/cms/site.yaml
@@ -1,1 +1,3 @@
 kind: "Site"
+apis:
+  - "asset"


### PR DESCRIPTION
## Summary

Migrate the deprecated `portal.assetUrl` calls in `cms/parts/form-part/form-part.js` over to `lib-asset` (`/lib/enonic/asset`).

This app's call sites are all in a site context (a page-part script), so the appropriate target per lib-asset's docs is `lib-asset`.

Closes #73

## Changes

- `build.gradle` — add `include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"`.
- `src/main/resources/cms/site.yaml` — register the universal `asset` API.
- `src/main/resources/cms/parts/form-part/form-part.js`:
  - import `/lib/enonic/asset` as `assetLib`
  - replace `portal.assetUrl(...)` at both call sites (`createCssUrl` and the form-script tag) with `assetLib.assetUrl(...)`. `/lib/xp/portal` is still imported for `portal.getComponent`, `portal.getContent`, `portal.getSiteConfig`, `portal.processHtml`, and `portal.pageUrl`.

## Test plan

- [x] `./gradlew build --refresh-dependencies` — clean build.
- [x] E2E inside `claude-dev` (inline XP-in-`/tmp` flow):
  - [x] `com.enonic.app.formbuilder` reaches ACTIVE.
  - [x] Created a `portal:site` content referencing the app (with the `bootstrap` style).
  - [x] `GET /site/default/master/fbtest/_/asset/com.enonic.app.formbuilder:<fingerprint>/js/formbuilder.js` returned HTTP 200 with the bundled `formbuilder.js` payload (6078 bytes). This is the URL the migrated `formScript = assetLib.assetUrl({ path: 'js/formbuilder.js' })` line generates.
  - [x] No errors in `server.log` related to the formbuilder bundle.